### PR TITLE
Update training set name in scope notebook

### DIFF
--- a/lectures/04/day04_SCoPe.ipynb
+++ b/lectures/04/day04_SCoPe.ipynb
@@ -88,7 +88,7 @@
     " \n",
     "- To start, open the `SCoPe training set column guide` on Google Drive to have a reference for the columns of the training set.\n",
     "\n",
-    "- Download the `downsampled_0.1_rs9_DR16_training_set.parquet` training set from Google Drive, placing it within your `scope` directory.\n",
+    "- Download the `DR16_merged_classifications_features_revamped_updated_imputed.parquet` training set from Google Drive, placing it within your `scope` directory.\n",
     " \n",
     "- Change the dataset path in `config.yaml` before running the following code. The path specifies the location within the `scope` directory where you put the training set. In `config.yaml`, the path can be found under `training: dataset: `."
    ]


### PR DESCRIPTION
This PR updates the name of the training set that the SCoPe notebook recommends users to download from Google Drive.